### PR TITLE
Allowing any major release of Hashie

### DIFF
--- a/cronofy.gemspec
+++ b/cronofy.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir['spec/**/*.rb']
 
   spec.add_runtime_dependency "oauth2", "~> 1.0"
-  spec.add_runtime_dependency "hashie", "~> 3.0"
+  spec.add_runtime_dependency "hashie", ">= 1.0"
 
   spec.add_development_dependency "bundler", "~>  1.6"
   spec.add_development_dependency "rake",    "~> 10.0"


### PR DESCRIPTION
Hello Cronofy Team,

I am submitting this PR for your review.  I had a conflict with my Gems last night, and it turned out that the Cronofy gem was requiring a high version of Hashie.  I have some older gem's in my gemfile and upgrading/updating those gems was not possible at the current moment.

That said, please review the proposed gem dependency change.  I see a lot of gem's out there require Hashie 1.0 or higher so this might be ok for your gem too?  Either way, feel free to merge or feel free to cancel.  Your call.

Here's the `bundle` output I was seeking to resolve, for your reference.


```bash
Bundler could not find compatible versions for gem "hashie":
  In Gemfile:
    tddium (>= 0) ruby depends on
      github_api (>= 0) ruby depends on
        hashie (>= 1.2) ruby

    omniauth-cronofy (>= 0) ruby depends on
      omniauth-oauth2 (~> 1.2) ruby depends on
        omniauth (~> 1.2) ruby depends on
          hashie (< 4, >= 1.2) ruby

    rocket_pants (>= 0) ruby depends on
      hashie (>= 1.0) ruby

    cronofy (~> 0.4.1) ruby depends on
      hashie (~> 3.0) ruby

    rocket_pants (>= 0) ruby depends on
      api_smith (>= 0) ruby depends on
        hashie (~> 1.0) ruby
```

Thanks,

Daniel Rice