### PR TITLE
Rename Cronofy::Credentials#to_hash to #to_h

### DIFF
--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -24,10 +24,10 @@ module Cronofy
     #           :refresh_token - An existing refresh token String for the user's
     #                            account (optional).
     def initialize(options = {})
-      access_token  = options[:access_token]
-      client_id     = options.fetch(:client_id, ENV["CRONOFY_CLIENT_ID"])
-      client_secret = options.fetch(:client_secret, ENV["CRONOFY_CLIENT_SECRET"])
-      refresh_token = options[:refresh_token]
+      access_token  = options[:access_token] || options['access_token']
+      client_id     = options[:client_id] || options['client_id'] || ENV["CRONOFY_CLIENT_ID"]
+      client_secret = options[:client_secret] || options['client_secret'] || ENV["CRONOFY_CLIENT_SECRET"]
+      refresh_token = options[:refresh_token] || options['refresh_token']
 
       @auth = Auth.new(client_id, client_secret, access_token, refresh_token)
     end

--- a/lib/cronofy/types.rb
+++ b/lib/cronofy/types.rb
@@ -18,7 +18,7 @@ module Cronofy
       @scope = oauth_token.params['scope']
     end
 
-    def to_hash
+    def to_h
       {
         access_token: access_token,
         expires_at: expires_at,


### PR DESCRIPTION
As per Matz's comment: https://bugs.ruby-lang.org/issues/10180#note-1
`#to_h` is idiomatic since `Cronofy::Credentials` cannot be duck-typable as a Hash.