### PR TITLE
correcting user_auth_link docs for state params

### DIFF
--- a/lib/cronofy/auth.rb
+++ b/lib/cronofy/auth.rb
@@ -22,8 +22,8 @@ module Cronofy
     #                (default: {}):
     #                :scope - Array of scopes describing the access to request
     #                         from the user to the users calendars (required).
-    #                :state - String containing the state value to retain during
-    #                         the OAuth authorization process (optional).
+    #                :state - Array of states to retain during the OAuth
+    #                         authorization process (optional).
     #
     # See http://www.cronofy.com/developers/api#authorization for reference.
     #

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -371,8 +371,8 @@ module Cronofy
     #                :scope - Array of scopes describing the access to request
     #                         from the user to the users calendars
     #                         (default: DEFAULT_OAUTH_SCOPE).
-    #                :state - String containing the state value to retain during
-    #                         the OAuth authorization process (optional).
+    #                :state - Array of states to retain during the OAuth
+    #                         authorization process (optional).
     #
     # See http://www.cronofy.com/developers/api#authorization for reference.
     #


### PR DESCRIPTION
@gshutler 

The docs for user_auth_link say to pass in a `String` but the [auth code expects an array](https://github.com/cronofy/cronofy-ruby/blob/master/lib/cronofy/auth.rb#L38).

If you want any wording changed, let me know.