### PR TITLE
Support use of different data centres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.18.0]
+
+ * Support multiple data centres [#30]
+
 ## [0.17.0]
 
  * Support member-specific available periods for Availability API [#27]
@@ -35,6 +39,7 @@
 [0.15.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.15.0
 [0.16.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.16.0
 [0.17.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.17.0
+[0.18.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.18.0
 
 [#13]: https://github.com/cronofy/cronofy-ruby/pull/13
 [#16]: https://github.com/cronofy/cronofy-ruby/pull/16
@@ -44,3 +49,4 @@
 [#24]: https://github.com/cronofy/cronofy-ruby/pull/24
 [#26]: https://github.com/cronofy/cronofy-ruby/pull/26
 [#27]: https://github.com/cronofy/cronofy-ruby/pull/27
+[#30]: https://github.com/cronofy/cronofy-ruby/pull/30

--- a/lib/cronofy.rb
+++ b/lib/cronofy.rb
@@ -7,19 +7,63 @@ require "cronofy/response_parser"
 require 'json'
 
 module Cronofy
-  def self.api_url
-    @api_url ||= (ENV['CRONOFY_API_URL'] || "https://api.cronofy.com")
+  def self.default_data_centre
+    @default_data_centre || ENV['CRONOFY_DATA_CENTRE']
+  end
+
+  def self.default_data_centre=(value)
+    @default_data_centre = value
+  end
+
+  def self.api_url(data_centre_override)
+    if data_centre_override
+      api_url_for_data_centre(data_centre_override)
+    else
+      ENV['CRONOFY_API_URL'] || api_url_for_data_centre(default_data_centre)
+    end
   end
 
   def self.api_url=(value)
     @api_url = value
   end
 
-  def self.app_url
-    @app_url ||= (ENV['CRONOFY_APP_URL'] || "https://app.cronofy.com")
+  def self.api_url_for_data_centre(dc)
+    @api_urls ||= Hash.new do |hash, key|
+      if key.nil? || key.to_sym == :us
+        url = "https://api.cronofy.com"
+      else
+        url = "https://api-#{key}.cronofy.com"
+      end
+
+      hash[key] = url.freeze
+    end
+
+    @api_urls[dc]
+  end
+
+  def self.app_url(data_centre_override)
+    if data_centre_override
+      app_url_for_data_centre(data_centre_override)
+    else
+      ENV['CRONOFY_APP_URL'] || app_url_for_data_centre(default_data_centre)
+    end
   end
 
   def self.app_url=(value)
     @app_url = value
+  end
+
+  def self.app_url_for_data_centre(dc)
+    @app_urls ||= Hash.new do |hash, key|
+      if key.nil? || key.to_sym == :us
+        url = "https://app.cronofy.com"
+      else
+        url = "https://app-#{key}.cronofy.com"
+      end
+
+      hash[key] = url.freeze
+    end
+
+    @app_urls[dc]
   end
 end

--- a/lib/cronofy/auth.rb
+++ b/lib/cronofy/auth.rb
@@ -5,13 +5,19 @@ module Cronofy
   class Auth
     attr_reader :access_token
 
-    def initialize(client_id, client_secret, token = nil, refresh_token = nil)
+    def initialize(options = {})
+      access_token = options[:access_token]
+      client_id = options[:client_id]
+      client_secret = options[:client_secret]
+      data_centre = options[:data_centre]
+      refresh_token = options[:refresh_token]
+
       @client_credentials_missing = blank?(client_id) || blank?(client_secret)
 
-      @auth_client = OAuth2::Client.new(client_id, client_secret, site: ::Cronofy.app_url, connection_opts: { headers: { "User-Agent" => "Cronofy Ruby #{::Cronofy::VERSION}" } })
-      @api_client = OAuth2::Client.new(client_id, client_secret, site: ::Cronofy.api_url, connection_opts: { headers: { "User-Agent" => "Cronofy Ruby #{::Cronofy::VERSION}" } })
+      @auth_client = OAuth2::Client.new(client_id, client_secret, site: ::Cronofy.app_url(data_centre), connection_opts: { headers: { "User-Agent" => "Cronofy Ruby #{::Cronofy::VERSION}" } })
+      @api_client = OAuth2::Client.new(client_id, client_secret, site: ::Cronofy.api_url(data_centre), connection_opts: { headers: { "User-Agent" => "Cronofy Ruby #{::Cronofy::VERSION}" } })
 
-      set_access_token(token, refresh_token) if token || refresh_token
+      set_access_token(access_token, refresh_token) if access_token || refresh_token
     end
 
     # Internal: generate a URL for authorizing the application with Cronofy

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -23,13 +23,23 @@ module Cronofy
     #                            ENV["CRONOFY_CLIENT_SECRET"]).
     #           :refresh_token - An existing refresh token String for the user's
     #                            account (optional).
+    #           :data_centre   - An identifier to override the default data
+    #                            centre (optional).
     def initialize(options = {})
       access_token  = options[:access_token]
       client_id     = options.fetch(:client_id, ENV["CRONOFY_CLIENT_ID"])
       client_secret = options.fetch(:client_secret, ENV["CRONOFY_CLIENT_SECRET"])
       refresh_token = options[:refresh_token]
 
-      @auth = Auth.new(client_id, client_secret, access_token, refresh_token)
+      @data_centre   = options[:data_centre]
+
+      @auth = Auth.new(
+        client_id: client_id,
+        client_secret: client_secret,
+        access_token: access_token,
+        refresh_token: refresh_token,
+        data_centre: @data_centre,
+      )
     end
 
     # Public: Creates a new calendar for the account.
@@ -207,7 +217,7 @@ module Cronofy
         params[tp] = to_iso8601(params[tp])
       end
 
-      url = ::Cronofy.api_url + "/v1/events"
+      url = api_url + "/v1/events"
       PagedResultIterator.new(PagedEventsResult, :events, access_token!, url, params)
     end
 
@@ -255,7 +265,7 @@ module Cronofy
         params[tp] = to_iso8601(params[tp])
       end
 
-      url = ::Cronofy.api_url + "/v1/free_busy"
+      url = api_url + "/v1/free_busy"
       PagedResultIterator.new(PagedFreeBusyResult, :free_busy, access_token!, url, params)
     end
 
@@ -890,6 +900,10 @@ module Cronofy
       def parse_page(response)
         ResponseParser.new(response).parse_json(@page_parser)
       end
+    end
+
+    def api_url
+      ::Cronofy.api_url(@data_centre)
     end
   end
 

--- a/lib/cronofy/version.rb
+++ b/lib/cronofy/version.rb
@@ -1,3 +1,3 @@
 module Cronofy
-  VERSION = "0.17.0".freeze
+  VERSION = "0.18.0".freeze
 end

--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -1283,4 +1283,44 @@ describe Cronofy::Client do
       end
     end
   end
+
+  describe "Specified data centre" do
+    let(:data_centre) { :de }
+
+    let(:client) do
+      Cronofy::Client.new(
+        client_id: 'client_id_123',
+        client_secret: 'client_secret_456',
+        access_token: token,
+        refresh_token: 'refresh_token_456',
+        data_centre: data_centre,
+      )
+    end
+
+    describe "Userinfo" do
+      let(:request_url) { "https://api-#{data_centre}.cronofy.com/v1/userinfo" }
+
+      describe "#userinfo" do
+        let(:method) { :get }
+
+        let(:correct_response_code) { 200 }
+        let(:correct_response_body) do
+          {
+            "sub" => "ser_5700a00eb0ccd07000000000",
+            "cronofy.type" => "service_account",
+            "cronofy.service_account.domain" => "example.com"
+          }
+        end
+
+        let(:correct_mapped_result) do
+          Cronofy::UserInfo.new(correct_response_body)
+        end
+
+        subject { client.userinfo }
+
+        it_behaves_like "a Cronofy request"
+        it_behaves_like "a Cronofy request with mapped return value"
+      end
+    end
+  end
 end


### PR DESCRIPTION
The data centre to use by default can be overridden by setting the `CRONOFY_DATA_CENTRE` environment variable or setting `Cronofy.default_data_centre` in code.

It can also be overridden on a case-by-case basis by specifying the `data_centre` parameter when creating a new `Cronofy::Client`.

#### Notes to reviewer

None.