### PR TITLE
Added spec to ensure calendar_ids serialized

### DIFF
--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -1273,6 +1273,71 @@ describe Cronofy::Client do
         it_behaves_like 'a Cronofy request with mapped return value'
       end
 
+      context "member-specific calendars" do
+        let(:request_body) do
+          {
+            "participants" => [
+              {
+                "members" => [
+                  { "sub" => "acc_567236000909002" },
+                  {
+                    "sub" => "acc_678347111010113",
+                    "calendar_ids" => [
+                      "cal_1234_5678",
+                      "cal_9876_5432",
+                    ]
+                  }
+                ],
+                "required" => "all"
+              }
+            ],
+            "required_duration" => { "minutes" => 60 },
+            "available_periods" => [
+              {
+                "start" => "2017-01-03T09:00:00Z",
+                "end" => "2017-01-03T18:00:00Z"
+              },
+              {
+                "start" => "2017-01-04T09:00:00Z",
+                "end" => "2017-01-04T18:00:00Z"
+              }
+            ]
+          }
+        end
+
+        let(:participants) do
+          [
+            {
+              members: [
+                { sub: "acc_567236000909002" },
+                {
+                  sub: "acc_678347111010113",
+                  calendar_ids: [
+                    "cal_1234_5678",
+                    "cal_9876_5432",
+                  ],
+                },
+              ],
+              required: :all,
+            }
+          ]
+        end
+
+        let(:required_duration) do
+          { minutes: 60 }
+        end
+
+        let(:available_periods) do
+          [
+            { start: Time.parse("2017-01-03T09:00:00Z"), end: Time.parse("2017-01-03T18:00:00Z") },
+            { start: Time.parse("2017-01-04T09:00:00Z"), end: Time.parse("2017-01-04T18:00:00Z") },
+          ]
+        end
+
+        it_behaves_like 'a Cronofy request'
+        it_behaves_like 'a Cronofy request with mapped return value'
+      end
+
       context "simple values to defaults" do
         let(:participants) do
           { members: %w{acc_567236000909002 acc_678347111010113} }


### PR DESCRIPTION
As it's a straight mapping of the API definition I don't feel it is worth [documenting in the class](https://github.com/cronofy/cronofy-ruby/blob/5151b9339e5e5e8da74f19a7ddc69530f6721258/lib/cronofy/client.rb#L667-L668) (plus the nesting would get crazy). Need an Availability API specific guide to cover this sort of thing I think.

#### Notes to reviewer

None.