### PR TITLE
Pass through times as-is if already Strings

### DIFF
--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -842,6 +842,8 @@ module Cronofy
       result = time
 
       case time
+      when String
+        time
       when Hash
         if time[:time]
           encoded_time = encode_event_time(time[:time])

--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -319,6 +319,13 @@ describe Cronofy::Client do
 
         it_behaves_like 'a Cronofy request'
       end
+
+      context 'when start and end already encoded' do
+        let(:start_datetime) { encoded_start_datetime }
+        let(:end_datetime) { encoded_end_datetime }
+
+        it_behaves_like 'a Cronofy request'
+      end
     end
 
     describe '#read_events' do


### PR DESCRIPTION
In some cases the client will already have the time formatted correctly and so provide it as a `String`.

Previously they would have to parse it as either a `Date` or a `Time` before passing it in, this avoids that additional set of parse-and-serialize.

#### Notes to reviewer

None.