### PR TITLE
Prevent error when disable_warnings not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.bundle/
 /.yardoc
-/Gemfile*.lock
+Gemfile*.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.27.1]
+
+ * Prevent error when disable\_warnings not available [#56]
+
 ## [0.26.0]
 
  * Support for batch endpoint [#53]
@@ -96,6 +100,7 @@
 [0.25.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.25.0
 [0.25.1]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.25.1
 [0.26.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.26.0
+[0.26.1]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.26.1
 
 [#13]: https://github.com/cronofy/cronofy-ruby/pull/13
 [#16]: https://github.com/cronofy/cronofy-ruby/pull/16
@@ -122,3 +127,4 @@
 [#52]: https://github.com/cronofy/cronofy-ruby/pull/52
 [#53]: https://github.com/cronofy/cronofy-ruby/pull/53
 [#55]: https://github.com/cronofy/cronofy-ruby/pull/55
+[#56]: https://github.com/cronofy/cronofy-ruby/pull/56

--- a/lib/cronofy/types.rb
+++ b/lib/cronofy/types.rb
@@ -187,7 +187,7 @@ module Cronofy
   class CronofyMash < Hashie::Mash
     include Hashie::Extensions::Coercion
 
-    disable_warnings
+    disable_warnings if respond_to?(:disable_warnings)
   end
 
   class Account < CronofyMash

--- a/lib/cronofy/version.rb
+++ b/lib/cronofy/version.rb
@@ -1,3 +1,3 @@
 module Cronofy
-  VERSION = "0.26.0".freeze
+  VERSION = "0.26.1".freeze
 end

--- a/script/bundle-update
+++ b/script/bundle-update
@@ -1,0 +1,23 @@
+#! /bin/bash
+
+# Fail fast
+set -o errexit
+
+dir=`dirname $0`
+source $dir/helpers
+
+echo
+pretty_echo "Removing Gemfile.locks"
+echo
+
+lockfiles=`find . -name Gemfile.lock`
+
+for lockfile in $lockfiles; do
+  echo "Removing $lockfile"
+  rm $lockfile
+done
+
+echo
+pretty_echo "Running CI"
+
+./$dir/ci

--- a/script/ci
+++ b/script/ci
@@ -3,6 +3,8 @@
 # Fail fast
 set -o errexit
 
+source $(dirname "$0")/helpers
+
 line_echo() {
   pretty_echo "-----------------------------------------"
 }

--- a/script/ci
+++ b/script/ci
@@ -3,18 +3,64 @@
 # Fail fast
 set -o errexit
 
-echo
-echo "Installing bundler"
-echo
-gem install bundler
-echo
+line_echo() {
+  pretty_echo "-----------------------------------------"
+}
 
-gemfiles="Gemfile Gemfile-downgraded-hashie"
+timed_run() {
+  echo
+  pretty_echo "$@ ($(date))"
+  echo
+  time "$@"
+  echo
+  line_echo
+}
 
-for gemfile in $gemfiles; do
+pretty_run() {
   echo
-  echo "Testing with $gemfile"
+  pretty_echo "$@ ($(date))"
   echo
-  bundle install --gemfile $gemfile
-  bundle exec rake spec
-done
+  eval "$@"
+  echo
+  line_echo
+}
+
+pretty_echo() {
+  if [ -t 1 ] ; then
+    echo -e "\x1B[1;36m$@\x1B[22;39m"
+  else
+    echo -e "$@"
+  fi
+}
+
+
+run_all() {
+  echo
+  pretty_run gem install bundler
+
+  echo
+  pretty_echo "Setting bundler paths"
+  echo
+  bundle_path=$(pwd)/vendor/bundle
+  bin_path=$bundle_path/bin
+  echo "Path: $bundle_path"
+  echo "Bin stubs: $bin_path"
+  echo
+  line_echo
+
+  gemfiles=`find spec/gemfiles -name Gemfile`
+
+  for gemfile in $gemfiles; do
+    echo
+    pretty_echo "Testing with $gemfile"
+    pretty_run bundle install --gemfile $gemfile --path $bundle_path --binstubs $bin_path
+    pretty_run bundle exec rake spec
+  done
+
+  echo
+  pretty_echo "Testing with default Gemfile"
+  pretty_run bundle install --gemfile Gemfile --path $bundle_path --binstubs $bin_path
+  pretty_run bundle exec rake spec
+}
+
+time run_all

--- a/script/helpers
+++ b/script/helpers
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+# Fail fast
+set -o errexit
+
+line_echo() {
+  pretty_echo "-----------------------------------------"
+}
+
+timed_run() {
+  echo
+  pretty_echo "$@ ($(date))"
+  echo
+  time "$@"
+  echo
+  line_echo
+}
+
+pretty_run() {
+  echo
+  pretty_echo "$@ ($(date))"
+  echo
+  eval "$@"
+  echo
+  line_echo
+}
+
+pretty_echo() {
+  if [ -t 1 ] ; then
+    echo -e "\x1B[1;36m$@\x1B[22;39m"
+  else
+    echo -e "$@"
+  fi
+}
+

--- a/spec/gemfiles/disable-warnings/Gemfile
+++ b/spec/gemfiles/disable-warnings/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: "../../.."
+
+gem "hashie", "3.4.2"

--- a/spec/gemfiles/downgraded-hashie/Gemfile
+++ b/spec/gemfiles/downgraded-hashie/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gemspec
+gemspec path: "../../.."
 
 gem "rack", "~> 1.0"
 gem "hashie", "~> 2.1.0"


### PR DESCRIPTION
Some versions of hashie do not have the disable_warnings method which results in an error at load time.

This change adds another Gemfile to the CI script, locked to a version without a disable_warnings implementation.