### PR TITLE
Assume Strings are already ISO8601 encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.28.1]
+
+ * Fixed double encoding issue [#59]
+
 ## [0.28.0]
 
  * Added support for handling subs from Token responses [#58]
@@ -111,6 +115,7 @@
 [0.26.1]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.26.1
 [0.27.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.27.0
 [0.28.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.28.0
+[0.28.1]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.28.1
 
 [#13]: https://github.com/cronofy/cronofy-ruby/pull/13
 [#16]: https://github.com/cronofy/cronofy-ruby/pull/16
@@ -140,3 +145,4 @@
 [#56]: https://github.com/cronofy/cronofy-ruby/pull/56
 [#57]: https://github.com/cronofy/cronofy-ruby/pull/57
 [#58]: https://github.com/cronofy/cronofy-ruby/pull/58
+[#59]: https://github.com/cronofy/cronofy-ruby/pull/59

--- a/lib/cronofy/time_encoding.rb
+++ b/lib/cronofy/time_encoding.rb
@@ -18,8 +18,8 @@ module Cronofy
 
     def to_iso8601(value)
       case value
-      when NilClass
-        nil
+      when NilClass, String
+        value
       when Time
         value.getutc.iso8601
       else

--- a/lib/cronofy/version.rb
+++ b/lib/cronofy/version.rb
@@ -1,3 +1,3 @@
 module Cronofy
-  VERSION = "0.28.0".freeze
+  VERSION = "0.28.1".freeze
 end

--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -1354,6 +1354,76 @@ describe Cronofy::Client do
         it_behaves_like 'a Cronofy request with mapped return value'
       end
 
+      context "reused member-specific available periods" do
+        let(:request_body) do
+          {
+            "participants" => [
+              {
+                "members" => [
+                  {
+                    "sub" => "acc_567236000909002",
+                    "available_periods" => [
+                      {
+                        "start" => "2017-01-03T09:00:00Z",
+                        "end" => "2017-01-03T12:00:00Z"
+                      },
+                    ]
+                  },
+                  {
+                    "sub" => "acc_678347111010113",
+                    "available_periods" => [
+                      {
+                        "start" => "2017-01-03T09:00:00Z",
+                        "end" => "2017-01-03T12:00:00Z"
+                      },
+                    ]
+                  }
+                ],
+                "required" => "all"
+              }
+            ],
+            "required_duration" => { "minutes" => 60 },
+            "available_periods" => [
+              {
+                "start" => "2017-01-03T09:00:00Z",
+                "end" => "2017-01-03T18:00:00Z"
+              },
+              {
+                "start" => "2017-01-04T09:00:00Z",
+                "end" => "2017-01-04T18:00:00Z"
+              }
+            ]
+          }
+        end
+
+        let(:participants) do
+          available_periods = [{ start: Time.parse("2017-01-03T09:00:00Z"), end: Time.parse("2017-01-03T12:00:00Z") }]
+          [
+            {
+              members: [
+                { sub: "acc_567236000909002", available_periods: available_periods },
+                { sub: "acc_678347111010113", available_periods: available_periods },
+              ],
+              required: :all,
+            }
+          ]
+        end
+
+        let(:required_duration) do
+          { minutes: 60 }
+        end
+
+        let(:available_periods) do
+          [
+            { start: Time.parse("2017-01-03T09:00:00Z"), end: Time.parse("2017-01-03T18:00:00Z") },
+            { start: Time.parse("2017-01-04T09:00:00Z"), end: Time.parse("2017-01-04T18:00:00Z") },
+          ]
+        end
+
+        it_behaves_like 'a Cronofy request'
+        it_behaves_like 'a Cronofy request with mapped return value'
+      end
+
       context "member-specific calendars" do
         let(:request_body) do
           {


### PR DESCRIPTION
If a Hash was reused within a nested object we could attempt to encode it twice when traversing the parameters of the call.

By assuming a String is already encoded correctly we avoid the second attempt at encoding it.