### PR TITLE
Fix invalid key in upsert_smart_invite documented example

### DIFF
--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -1258,7 +1258,7 @@ module Cronofy
     #   client.upsert_smart_invite(
     #     smart_invite_id: "qTtZdczOccgaPncGJaCiLg",
     #     callback_url: "http://www.example.com",
-    #     attendee: {
+    #     recipient: {
     #       email: "example@example.com"
     #     },
     #     event: {


### PR DESCRIPTION
I noticed that the documented example for using `upsert_smart_invite` uses a wrong key for recipient. It should be `recipient` and not `attendee`?

If this is indeed a mistake, this is also present in the `CREATE YOUR FIRST INVITE` ruby code snippet under the Smart Invite Tutorial.

Thanks :)