### PR TITLE
Add specific errors for network issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.35.0]
+
+ * Add specific errors for network issues [#77]
+
 ## [0.34.0]
 
  * Support removing a participant from a Smart Invite [#75]
@@ -157,6 +161,7 @@
 [0.32.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.32.0
 [0.33.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.33.0
 [0.34.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.34.0
+[0.35.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.35.0
 
 [#13]: https://github.com/cronofy/cronofy-ruby/pull/13
 [#16]: https://github.com/cronofy/cronofy-ruby/pull/16
@@ -195,3 +200,4 @@
 [#73]: https://github.com/cronofy/cronofy-ruby/pull/73
 [#74]: https://github.com/cronofy/cronofy-ruby/pull/74
 [#75]: https://github.com/cronofy/cronofy-ruby/pull/75
+[#77]: https://github.com/cronofy/cronofy-ruby/pull/77

--- a/lib/cronofy/errors.rb
+++ b/lib/cronofy/errors.rb
@@ -71,6 +71,15 @@ module Cronofy
   class ServiceUnreachableError < APIError
   end
 
+  class BadGatewayError < ServiceUnreachableError
+  end
+
+  class ServiceUnavailableError < ServiceUnreachableError
+  end
+
+  class GatewayTimeoutError < ServiceUnreachableError
+  end
+
   class UnknownError < APIError
   end
 
@@ -86,9 +95,9 @@ module Cronofy
       423 => AccountLockedError,
       429 => TooManyRequestsError,
       500 => ServerError,
-      502 => ServiceUnreachableError,
-      503 => ServiceUnreachableError,
-      504 => ServiceUnreachableError,
+      502 => BadGatewayError,
+      503 => ServiceUnavailableError,
+      504 => GatewayTimeoutError,
     }.freeze
 
     def self.map_error(error)

--- a/lib/cronofy/errors.rb
+++ b/lib/cronofy/errors.rb
@@ -68,6 +68,9 @@ module Cronofy
   class PaymentRequiredError < APIError
   end
 
+  class ServiceUnreachableError < APIError
+  end
+
   class UnknownError < APIError
   end
 
@@ -83,6 +86,9 @@ module Cronofy
       423 => AccountLockedError,
       429 => TooManyRequestsError,
       500 => ServerError,
+      502 => ServiceUnreachableError,
+      503 => ServiceUnreachableError,
+      504 => ServiceUnreachableError,
     }.freeze
 
     def self.map_error(error)

--- a/lib/cronofy/version.rb
+++ b/lib/cronofy/version.rb
@@ -1,3 +1,3 @@
 module Cronofy
-  VERSION = "0.34.0".freeze
+  VERSION = "0.35.0".freeze
 end


### PR DESCRIPTION
Add new errors to help with networking issues:
  * `BadGatewayError` (HTTP 502)
  * `ServiceUnavailableError` (HTTP 503)
  * `GatewayTimeoutError` (HTTP 504)
 
Each inherrits from `ServiceUnreachableError` for easier `rescue`ing
