### PR TITLE
Update webmock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
 
 cache:
   - bundler

--- a/cronofy.gemspec
+++ b/cronofy.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">=  1.6", "< 3"
   spec.add_development_dependency "rake",    "~> 10.0"
   spec.add_development_dependency "rspec",   "~>  3.2"
-  spec.add_development_dependency "webmock", "~>  1.21"
+  spec.add_development_dependency "webmock", "~>  3.9.1"
 end


### PR DESCRIPTION
TravisCI is failing and issues point to it being down to an old issue in webmock. This PR updates Webmock to the latest version and adds Ruby 2.7 to the Travis testing list.