### PR TITLE
Revoke by sub & token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## [0.37.0]
+
+ * Add `revoke_by_token` and `revoke_by_sub` to the Client [#86] 
+
 ## [0.36.1]
 
-* Loosen the version requirement on Hashie to allow 4.X
+ * Loosen the version requirement on Hashie to allow 4.X
 
 ## [0.36.0]
 
@@ -172,6 +176,7 @@
 [0.35.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.35.0
 [0.36.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.36.0
 [0.36.1]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.36.1
+[0.37.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.37.0
 
 [#13]: https://github.com/cronofy/cronofy-ruby/pull/13
 [#16]: https://github.com/cronofy/cronofy-ruby/pull/16
@@ -213,3 +218,4 @@
 [#77]: https://github.com/cronofy/cronofy-ruby/pull/77
 [#81]: https://github.com/cronofy/cronofy-ruby/pull/81
 [#85]: https://github.com/cronofy/cronofy-ruby/pull/85
+[#86]: https://github.com/cronofy/cronofy-ruby/pull/86

--- a/lib/cronofy/auth.rb
+++ b/lib/cronofy/auth.rb
@@ -115,15 +115,20 @@ module Cronofy
     # Returns nothing.
     #
     # Raises Cronofy::CredentialsMissingError if no credentials available.
-    def revoke!
-      raise CredentialsMissingError.new("No credentials to revoke") unless access_token
+    def revoke!(sub: nil)
+      raise CredentialsMissingError.new("No credentials to revoke") unless access_token || sub
 
       do_request do
         body = {
           client_id: @api_client.id,
           client_secret: @api_client.secret,
-          token: access_token.refresh_token || access_token.token,
         }
+
+        if sub
+          body.merge!(sub: sub)
+        else
+          body.merge!(token: access_token.refresh_token || access_token.token)
+        end
 
         @api_client.request(:post, "/oauth/token/revoke", body: body)
         @access_token = nil

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -733,8 +733,16 @@ module Cronofy
     # Raises Cronofy::AuthenticationFailureError if the client ID and secret are
     # not valid.
     # Raises Cronofy::CredentialsMissingError if no credentials available.
-    def revoke_authorization(sub: nil)
-      @auth.revoke!(sub: sub)
+    def revoke_authorization
+      @auth.revoke!
+    end
+
+    def revoke_by_sub(sub)
+      @auth.revoke_by_sub(sub)
+    end
+
+    def revoke_by_token(token)
+      @auth.revoke_by_token(token)
     end
 
     # Public: Requests elevated permissions for a set of calendars.

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -733,8 +733,8 @@ module Cronofy
     # Raises Cronofy::AuthenticationFailureError if the client ID and secret are
     # not valid.
     # Raises Cronofy::CredentialsMissingError if no credentials available.
-    def revoke_authorization
-      @auth.revoke!
+    def revoke_authorization(sub: nil)
+      @auth.revoke!(sub: sub)
     end
 
     # Public: Requests elevated permissions for a set of calendars.

--- a/lib/cronofy/version.rb
+++ b/lib/cronofy/version.rb
@@ -1,3 +1,3 @@
 module Cronofy
-  VERSION = "0.36.1".freeze
+  VERSION = "0.37.0".freeze
 end

--- a/spec/lib/cronofy/auth_spec.rb
+++ b/spec/lib/cronofy/auth_spec.rb
@@ -411,7 +411,7 @@ describe Cronofy::Auth do
       end
 
       before do
-        auth.revoke!(sub: nil)
+        auth.revoke!
       end
 
       it "unsets the access token" do
@@ -466,46 +466,6 @@ describe Cronofy::Auth do
       it_behaves_like 'successful revocation'
     end
 
-    context "when revoking by sub instead" do
-      let(:auth) do
-        Cronofy::Auth.new(
-          client_id: client_id,
-          client_secret: client_secret,
-          access_token: access_token,
-          refresh_token: refresh_token,
-        )
-      end
-
-      let!(:revocation_request) do
-        stub_request(:post, "https://api.cronofy.com/oauth/token/revoke")
-          .with(
-            body: {
-              client_id: client_id,
-              client_secret: client_secret,
-              sub: sub,
-            },
-            headers: {
-              'Content-Type' => 'application/x-www-form-urlencoded',
-              'User-Agent' => "Cronofy Ruby #{Cronofy::VERSION}",
-            }
-          ).to_return(status: response_status)
-      end
-
-      let(:sub) { "random_sub_value" }
-
-      before do
-        auth.revoke!(sub: sub)
-      end
-
-      it "unsets the access token" do
-        expect(auth.access_token).to be_nil
-      end
-
-      it "makes the revocation request" do
-        expect(revocation_request).to have_been_requested
-      end
-    end
-
     context "no access_token or refresh_token" do
       let(:auth) do
         Cronofy::Auth.new(client_id: client_id, client_secret: client_secret)
@@ -514,6 +474,86 @@ describe Cronofy::Auth do
       it "raises a credentials missing error" do
         expect { auth.revoke! }.to raise_error(Cronofy::CredentialsMissingError)
       end
+    end
+  end
+
+  describe "#revoke_by_sub" do
+    let(:auth) do
+      Cronofy::Auth.new(
+        client_id: client_id,
+        client_secret: client_secret,
+        access_token: access_token,
+        refresh_token: refresh_token,
+      )
+    end
+
+    let!(:revocation_request) do
+      stub_request(:post, "https://api.cronofy.com/oauth/token/revoke")
+        .with(
+          body: {
+            client_id: client_id,
+            client_secret: client_secret,
+            sub: sub,
+          },
+          headers: {
+            'Content-Type' => 'application/x-www-form-urlencoded',
+            'User-Agent' => "Cronofy Ruby #{Cronofy::VERSION}",
+          }
+        ).to_return(status: response_status)
+    end
+
+    let(:sub) { "random_sub_value" }
+
+    before do
+      auth.revoke_by_sub(sub)
+    end
+
+    it "does not unset the access token for the current auth" do
+      expect(auth.access_token).not_to be_nil
+    end
+
+    it "makes the revocation request" do
+      expect(revocation_request).to have_been_requested
+    end
+  end
+
+  describe "#revoke_by_token" do
+    let(:auth) do
+      Cronofy::Auth.new(
+        client_id: client_id,
+        client_secret: client_secret,
+        access_token: access_token,
+        refresh_token: refresh_token,
+      )
+    end
+
+    let!(:revocation_request) do
+      stub_request(:post, "https://api.cronofy.com/oauth/token/revoke")
+        .with(
+          body: {
+            client_id: client_id,
+            client_secret: client_secret,
+            token: token,
+          },
+          headers: {
+            'Content-Type' => 'application/x-www-form-urlencoded',
+            'User-Agent' => "Cronofy Ruby #{Cronofy::VERSION}",
+          }
+        ).to_return(status: response_status)
+    end
+
+    let(:token) { "random_token_value" }
+
+    before do
+      auth.revoke_by_token(token)
+    end
+
+    it "does not unset the access token for the current auth" do
+      expect(auth.access_token).not_to be_nil
+    end
+
+    it "makes the revocation request" do
+      expect(revocation_request).to have_been_requested
     end
   end
 end

--- a/spec/lib/cronofy/auth_spec.rb
+++ b/spec/lib/cronofy/auth_spec.rb
@@ -411,7 +411,7 @@ describe Cronofy::Auth do
       end
 
       before do
-        auth.revoke!
+        auth.revoke!(sub: nil)
       end
 
       it "unsets the access token" do
@@ -464,6 +464,46 @@ describe Cronofy::Auth do
       let(:revoke_token) { access_token }
 
       it_behaves_like 'successful revocation'
+    end
+
+    context "when revoking by sub instead" do
+      let(:auth) do
+        Cronofy::Auth.new(
+          client_id: client_id,
+          client_secret: client_secret,
+          access_token: access_token,
+          refresh_token: refresh_token,
+        )
+      end
+
+      let!(:revocation_request) do
+        stub_request(:post, "https://api.cronofy.com/oauth/token/revoke")
+          .with(
+            body: {
+              client_id: client_id,
+              client_secret: client_secret,
+              sub: sub,
+            },
+            headers: {
+              'Content-Type' => 'application/x-www-form-urlencoded',
+              'User-Agent' => "Cronofy Ruby #{Cronofy::VERSION}",
+            }
+          ).to_return(status: response_status)
+      end
+
+      let(:sub) { "random_sub_value" }
+
+      before do
+        auth.revoke!(sub: sub)
+      end
+
+      it "unsets the access token" do
+        expect(auth.access_token).to be_nil
+      end
+
+      it "makes the revocation request" do
+        expect(revocation_request).to have_been_requested
+      end
     end
 
     context "no access_token or refresh_token" do


### PR DESCRIPTION
Adds two new methods to the Client:
* `revoke_by_sub`
* `revoke_by_token`

Both all revocation of accounts other than the one active, using the application credentials.