### PR TITLE
Accept `data_center` as well as `data_centre`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.37.1]
+
+ * Rename `data_centre` to `data_centre` (with aliases for backwards compatibility) [#90] 
+
 ## [0.37.0]
 
  * Add `revoke_by_token` and `revoke_by_sub` to the Client [#86] 
@@ -177,6 +181,7 @@
 [0.36.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.36.0
 [0.36.1]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.36.1
 [0.37.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.37.0
+[0.37.1]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.37.1
 
 [#13]: https://github.com/cronofy/cronofy-ruby/pull/13
 [#16]: https://github.com/cronofy/cronofy-ruby/pull/16
@@ -219,3 +224,4 @@
 [#81]: https://github.com/cronofy/cronofy-ruby/pull/81
 [#85]: https://github.com/cronofy/cronofy-ruby/pull/85
 [#86]: https://github.com/cronofy/cronofy-ruby/pull/86
+[#90]: https://github.com/cronofy/cronofy-ruby/pull/90

--- a/README.md
+++ b/README.md
@@ -29,14 +29,15 @@ to obtain an OAuth `client_id` and `client_secret` to be able to use the full AP
 ## Creating a client
 
 To make calls to the Cronofy API you must create a `Cronofy::Client`. This takes
-four keyword arguments, all of which are optional:
+five keyword arguments, all of which are optional:
 
 ```ruby
 cronofy = Cronofy::Client.new(
   client_id:     'CLIENT_ID',
   client_secret: 'CLIENT_SECRET',
   access_token:  'ACCESS_TOKEN',
-  refresh_token: 'REFRESH_TOKEN'
+  refresh_token: 'REFRESH_TOKEN',
+  data_center:   :de
 )
 ```
 
@@ -50,6 +51,8 @@ for a user, and when [refreshing an access token](https://www.cronofy.com/develo
 If `client_id` and `client_secret` are not specified explicitly the values from
 the environment variables `CRONOFY_CLIENT_ID` and `CRONOFY_CLIENT_SECRET` will
 be used if present.
+
+`data_center` is the two-letter designation for the data center you want to operate against - for example `:de` for Germany, or `:au` for Australia. When omitted, this defaults to the US data center.
 
 ## Authorization
 

--- a/lib/cronofy.rb
+++ b/lib/cronofy.rb
@@ -13,18 +13,26 @@ require 'openssl'
 
 module Cronofy
   def self.default_data_centre
-    @default_data_centre || ENV['CRONOFY_DATA_CENTRE']
+    default_data_center
   end
 
   def self.default_data_centre=(value)
-    @default_data_centre = value
+    default_data_center= value
   end
 
-  def self.api_url(data_centre_override)
-    if data_centre_override
-      api_url_for_data_centre(data_centre_override)
+  def self.default_data_center
+    @default_data_center || ENV['CRONOFY_DATA_CENTER'] || ENV['CRONOFY_DATA_CENTRE']
+  end
+
+  def self.default_data_center=(value)
+    @default_data_center = value
+  end
+
+  def self.api_url(data_center_override)
+    if data_center_override
+      api_url_for_data_center(data_center_override)
     else
-      ENV['CRONOFY_API_URL'] || api_url_for_data_centre(default_data_centre)
+      ENV['CRONOFY_API_URL'] || api_url_for_data_center(default_data_center)
     end
   end
 
@@ -32,7 +40,11 @@ module Cronofy
     @api_url = value
   end
 
-  def self.api_url_for_data_centre(dc)
+  def self.api_url_for_data_centre
+    api_url_for_data_center
+  end
+
+  def self.api_url_for_data_center(dc)
     @api_urls ||= Hash.new do |hash, key|
       if key.nil? || key.to_sym == :us
         url = "https://api.cronofy.com"
@@ -46,11 +58,11 @@ module Cronofy
     @api_urls[dc]
   end
 
-  def self.app_url(data_centre_override)
-    if data_centre_override
-      app_url_for_data_centre(data_centre_override)
+  def self.app_url(data_center_override)
+    if data_center_override
+      app_url_for_data_center(data_center_override)
     else
-      ENV['CRONOFY_APP_URL'] || app_url_for_data_centre(default_data_centre)
+      ENV['CRONOFY_APP_URL'] || app_url_for_data_center(default_data_center)
     end
   end
 
@@ -59,6 +71,10 @@ module Cronofy
   end
 
   def self.app_url_for_data_centre(dc)
+    app_url_for_data_center(dc)
+  end
+
+  def self.app_url_for_data_center(dc)
     @app_urls ||= Hash.new do |hash, key|
       if key.nil? || key.to_sym == :us
         url = "https://app.cronofy.com"

--- a/lib/cronofy/auth.rb
+++ b/lib/cronofy/auth.rb
@@ -11,13 +11,13 @@ module Cronofy
       access_token = options[:access_token]
       client_id = options[:client_id]
       client_secret = options[:client_secret]
-      data_centre = options[:data_centre]
+      data_center = options[:data_center]
       refresh_token = options[:refresh_token]
 
       @client_credentials_missing = blank?(client_id) || blank?(client_secret)
 
-      @auth_client = OAuth2::Client.new(client_id, client_secret, site: ::Cronofy.app_url(data_centre), connection_opts: { headers: { "User-Agent" => "Cronofy Ruby #{::Cronofy::VERSION}" } })
-      @api_client = OAuth2::Client.new(client_id, client_secret, site: ::Cronofy.api_url(data_centre), connection_opts: { headers: { "User-Agent" => "Cronofy Ruby #{::Cronofy::VERSION}" } })
+      @auth_client = OAuth2::Client.new(client_id, client_secret, site: ::Cronofy.app_url(data_center), connection_opts: { headers: { "User-Agent" => "Cronofy Ruby #{::Cronofy::VERSION}" } })
+      @api_client = OAuth2::Client.new(client_id, client_secret, site: ::Cronofy.api_url(data_center), connection_opts: { headers: { "User-Agent" => "Cronofy Ruby #{::Cronofy::VERSION}" } })
 
       set_access_token(access_token, refresh_token) if access_token || refresh_token
       set_api_key(client_secret) if client_secret

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -28,21 +28,21 @@ module Cronofy
     #           :refresh_token - An existing refresh token String for the user's
     #                            account (optional).
     #           :data_center   - An identifier to override the default data
-    #                            centre (optional).
+    #                            center (optional).
     def initialize(options = {})
       access_token  = options[:access_token]
       refresh_token = options[:refresh_token]
 
       @client_id     = options.fetch(:client_id, ENV["CRONOFY_CLIENT_ID"])
       @client_secret = options.fetch(:client_secret, ENV["CRONOFY_CLIENT_SECRET"])
-      @data_centre   = options[:data_center] || options[:data_centre]
+      @data_center   = options[:data_center] || options[:data_centre]
 
       @auth = Auth.new(
         client_id: @client_id,
         client_secret: @client_secret,
         access_token: access_token,
         refresh_token: refresh_token,
-        data_centre: @data_centre
+        data_center: @data_center
       )
     end
 
@@ -1889,7 +1889,7 @@ module Cronofy
     end
 
     def api_url
-      ::Cronofy.api_url(@data_centre)
+      ::Cronofy.api_url(@data_center)
     end
   end
 

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -27,7 +27,7 @@ module Cronofy
     #                            ENV["CRONOFY_CLIENT_SECRET"]).
     #           :refresh_token - An existing refresh token String for the user's
     #                            account (optional).
-    #           :data_centre   - An identifier to override the default data
+    #           :data_center   - An identifier to override the default data
     #                            centre (optional).
     def initialize(options = {})
       access_token  = options[:access_token]
@@ -35,14 +35,14 @@ module Cronofy
 
       @client_id     = options.fetch(:client_id, ENV["CRONOFY_CLIENT_ID"])
       @client_secret = options.fetch(:client_secret, ENV["CRONOFY_CLIENT_SECRET"])
-      @data_centre   = options[:data_centre]
+      @data_centre   = options[:data_center] || options[:data_centre]
 
       @auth = Auth.new(
         client_id: @client_id,
         client_secret: @client_secret,
         access_token: access_token,
         refresh_token: refresh_token,
-        data_centre: @data_centre,
+        data_centre: @data_centre
       )
     end
 

--- a/lib/cronofy/version.rb
+++ b/lib/cronofy/version.rb
@@ -1,3 +1,3 @@
 module Cronofy
-  VERSION = "0.37.0".freeze
+  VERSION = "0.37.1".freeze
 end

--- a/spec/lib/cronofy/auth_spec.rb
+++ b/spec/lib/cronofy/auth_spec.rb
@@ -92,7 +92,7 @@ describe Cronofy::Auth do
     let(:scheme) { 'https' }
     let(:host) { 'app.cronofy.com' }
     let(:path) { '/oauth/authorize' }
-    let(:data_centre_override) { nil }
+    let(:data_center_override) { nil }
     let(:default_params) do
       {
         'client_id' => client_id,
@@ -106,7 +106,7 @@ describe Cronofy::Auth do
       Cronofy::Auth.new(
         client_id: client_id,
         client_secret: client_secret,
-        data_centre: data_centre_override,
+        data_center: data_center_override,
       )
     end
 
@@ -156,8 +156,8 @@ describe Cronofy::Auth do
       it_behaves_like 'a user auth link provider'
     end
 
-    context 'when data centre overridden' do
-      let(:data_centre_override) { :de }
+    context 'when data center overridden' do
+      let(:data_center_override) { :de }
       let(:host) { 'app-de.cronofy.com' }
       let(:params) { default_params }
 
@@ -204,13 +204,13 @@ describe Cronofy::Auth do
   end
 
   describe '#get_token_from_code' do
-    let(:data_centre_override) { nil }
+    let(:data_center_override) { nil }
 
     subject do
       Cronofy::Auth.new(
         client_id: client_id,
         client_secret: client_secret,
-        data_centre: data_centre_override,
+        data_center: data_center_override,
       ).get_token_from_code(code, redirect_uri)
     end
 
@@ -236,7 +236,7 @@ describe Cronofy::Auth do
     end
 
     describe '#application_calendar' do
-      let(:data_centre_override) { nil }
+      let(:data_center_override) { nil }
 
       let(:application_calendar_id) { "my-application-calendar" }
       let(:cronofy_application_calendar_id) { "apc_54475485743" }
@@ -273,7 +273,7 @@ describe Cronofy::Auth do
         Cronofy::Auth.new(
           client_id: client_id,
           client_secret: client_secret,
-          data_centre: data_centre_override,
+          data_center: data_center_override,
         ).application_calendar(application_calendar_id)
       end
 
@@ -308,8 +308,8 @@ describe Cronofy::Auth do
       end
     end
 
-    context "with data centre overridden" do
-      let(:data_centre_override) { :de }
+    context "with data center overridden" do
+      let(:data_center_override) { :de }
       let(:api_token_url) { "https://api-de.cronofy.com/oauth/token" }
       let(:app_token_url) { "https://app-de.cronofy.com/oauth/token" }
 
@@ -372,14 +372,14 @@ describe Cronofy::Auth do
       it_behaves_like 'an authorization request'
     end
 
-    context "with data centre overridden" do
+    context "with data center overridden" do
       subject do
         Cronofy::Auth.new(
           client_id: client_id,
           client_secret: client_secret,
           access_token: access_token,
           refresh_token: refresh_token,
-          data_centre: :de,
+          data_center: :de,
         ).refresh!
       end
 

--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -2325,7 +2325,7 @@ describe Cronofy::Client do
 
   end
 
-  describe "Specified data centre" do
+  describe "specifying data_centre" do
     let(:data_centre) { :de }
 
     let(:client) do
@@ -2340,6 +2340,46 @@ describe Cronofy::Client do
 
     describe "Userinfo" do
       let(:request_url) { "https://api-#{data_centre}.cronofy.com/v1/userinfo" }
+
+      describe "#userinfo" do
+        let(:method) { :get }
+
+        let(:correct_response_code) { 200 }
+        let(:correct_response_body) do
+          {
+            "sub" => "ser_5700a00eb0ccd07000000000",
+            "cronofy.type" => "service_account",
+            "cronofy.service_account.domain" => "example.com"
+          }
+        end
+
+        let(:correct_mapped_result) do
+          Cronofy::UserInfo.new(correct_response_body)
+        end
+
+        subject { client.userinfo }
+
+        it_behaves_like "a Cronofy request"
+        it_behaves_like "a Cronofy request with mapped return value"
+      end
+    end
+  end
+
+  describe "specifying data_center" do
+    let(:data_center) { :au }
+
+    let(:client) do
+      Cronofy::Client.new(
+        client_id: 'client_id_123',
+        client_secret: 'client_secret_456',
+        access_token: token,
+        refresh_token: 'refresh_token_456',
+        data_center: data_center,
+      )
+    end
+
+    describe "Userinfo" do
+      let(:request_url) { "https://api-#{data_center}.cronofy.com/v1/userinfo" }
 
       describe "#userinfo" do
         let(:method) { :get }

--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -2326,7 +2326,7 @@ describe Cronofy::Client do
   end
 
   describe "specifying data_centre" do
-    let(:data_centre) { :de }
+    let(:data_center) { :de }
 
     let(:client) do
       Cronofy::Client.new(
@@ -2334,12 +2334,12 @@ describe Cronofy::Client do
         client_secret: 'client_secret_456',
         access_token: token,
         refresh_token: 'refresh_token_456',
-        data_centre: data_centre,
+        data_centre: data_center,
       )
     end
 
     describe "Userinfo" do
-      let(:request_url) { "https://api-#{data_centre}.cronofy.com/v1/userinfo" }
+      let(:request_url) { "https://api-#{data_center}.cronofy.com/v1/userinfo" }
 
       describe "#userinfo" do
         let(:method) { :get }


### PR DESCRIPTION
Accept both spellings, as well as calling it our more clearly in the README to address #89 