### PR TITLE
Support query_periods key in availability queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.37.2]
+
+ * Support `query_periods` as well as the original `available_periods` for Availability Query and Sequenced Availability [#91] 
+
 ## [0.37.1]
 
  * Rename `data_centre` to `data_centre` (with aliases for backwards compatibility) [#90] 
@@ -182,6 +186,7 @@
 [0.36.1]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.36.1
 [0.37.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.37.0
 [0.37.1]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.37.1
+[0.37.2]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.37.2
 
 [#13]: https://github.com/cronofy/cronofy-ruby/pull/13
 [#16]: https://github.com/cronofy/cronofy-ruby/pull/16
@@ -225,3 +230,4 @@
 [#85]: https://github.com/cronofy/cronofy-ruby/pull/85
 [#86]: https://github.com/cronofy/cronofy-ruby/pull/86
 [#90]: https://github.com/cronofy/cronofy-ruby/pull/90
+[#91]: https://github.com/cronofy/cronofy-ruby/pull/91

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -861,7 +861,7 @@ module Cronofy
     #                                of minutes for the availability query.
     #             :buffer            - An Hash containing the buffer to apply to
     #                                the availability query.
-    #             :available_periods - An Array of available time periods Hashes,
+    #             :query_periods     - An Array of available time periods Hashes,
     #                                each must specify a start and end Time.
     #
     # Returns an Array of Sequences.
@@ -878,7 +878,7 @@ module Cronofy
     def sequenced_availability(options = {})
       options[:sequence] = map_availability_sequence(options[:sequence])
 
-      translate_available_periods(options[:available_periods])
+      translate_available_periods(options[:query_periods] || options[:available_periods])
 
       response = post("/v1/sequenced_availability", options)
       parse_collection(Sequence, "sequences", response)

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -803,7 +803,7 @@ module Cronofy
     #                                for a single participant group.
     #           :required_duration - An Integer representing the minimum number
     #                                of minutes of availability required.
-    #           :available_periods - An Array of available time periods Hashes,
+    #           :query_periods     - An Array of available time periods Hashes,
     #                                each must specify a start and end Time.
     #           :start_interval    - An Integer representing the start interval
     #                                of minutes for the availability query.
@@ -833,7 +833,7 @@ module Cronofy
         options[:buffer] = map_availability_buffer(buffer)
       end
 
-      translate_available_periods(options[:available_periods])
+      translate_available_periods(options[:query_periods] || options[:available_periods])
 
       response = post("/v1/availability", options)
 
@@ -847,7 +847,7 @@ module Cronofy
     # Public: Performs an sequenced availability query.
     #
     # options - The Hash options used to refine the selection (default: {}):
-    #           :sequence          - An Array of sequence defintions containing
+    #             :sequence          - An Array of sequence defintions containing
     #                                a Hash of:
     #             :sequence_id       - A String to uniquely identify this part
     #                                of the proposed sequence.
@@ -861,7 +861,7 @@ module Cronofy
     #                                of minutes for the availability query.
     #             :buffer            - An Hash containing the buffer to apply to
     #                                the availability query.
-    #           :available_periods - An Array of available time periods Hashes,
+    #             :available_periods - An Array of available time periods Hashes,
     #                                each must specify a start and end Time.
     #
     # Returns an Array of Sequences.

--- a/lib/cronofy/version.rb
+++ b/lib/cronofy/version.rb
@@ -1,3 +1,3 @@
 module Cronofy
-  VERSION = "0.37.1".freeze
+  VERSION = "0.37.2".freeze
 end

--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -266,6 +266,7 @@ describe Cronofy::Client do
           ],
         }
       end
+
       let(:request_body) do
         {
           :event_id => "qTtZdczOccgaPncGJaCiLg",
@@ -1713,6 +1714,57 @@ describe Cronofy::Client do
             { start: Time.parse("2017-01-03T09:00:00Z"), end: Time.parse("2017-01-03T18:00:00Z") },
             { start: Time.parse("2017-01-04T09:00:00Z"), end: Time.parse("2017-01-04T18:00:00Z") },
           ]
+        end
+
+        it_behaves_like 'a Cronofy request'
+        it_behaves_like 'a Cronofy request with mapped return value'
+      end
+
+      context "when given query_periods instead of available_periods" do
+        let(:participants) do
+          { members: %w{acc_567236000909002 acc_678347111010113} }
+        end
+
+        let(:required_duration) { 60 }
+
+        let(:query_periods) do
+          [
+            { start: Time.parse("2017-01-03T09:00:00Z"), end: Time.parse("2017-01-03T18:00:00Z") },
+            { start: Time.parse("2017-01-04T09:00:00Z"), end: Time.parse("2017-01-04T18:00:00Z") },
+          ]
+        end
+
+        let(:request_body) do
+          {
+            "participants" => [
+              {
+                "members" => [
+                  { "sub" => "acc_567236000909002" },
+                  { "sub" => "acc_678347111010113" }
+                ],
+                "required" => "all"
+              }
+            ],
+            "query_periods" => [
+              {
+                "start" => "2017-01-03T09:00:00Z",
+                "end" => "2017-01-03T18:00:00Z"
+              },
+              {
+                "start" => "2017-01-04T09:00:00Z",
+                "end" => "2017-01-04T18:00:00Z"
+              }
+            ],
+            "required_duration" => { "minutes" => 60 },
+          }
+        end
+
+        subject do
+          client.availability(
+            participants: participants,
+            required_duration: required_duration,
+            query_periods: query_periods
+          )
         end
 
         it_behaves_like 'a Cronofy request'

--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -1925,6 +1925,18 @@ describe Cronofy::Client do
 
       it_behaves_like 'a Cronofy request'
       it_behaves_like 'a Cronofy request with mapped return value'
+
+      context "when passing query_periods instead" do
+        before do
+          args[:query_periods] = args[:available_periods]
+          args.delete(:available_periods)
+          request_body["query_periods"] = request_body["available_periods"]
+          request_body.delete("available_periods")
+        end
+
+        it_behaves_like 'a Cronofy request'
+        it_behaves_like 'a Cronofy request with mapped return value'
+      end
     end
   end
 


### PR DESCRIPTION
Add support for the rename of `availabile_periods` -> `query_periods` in `client#availability`

Currently this will result in a confusing "no method `each` for nil" error; this PR fixes this issue so values copied from the docs work without error.