### PR TITLE
adding multiple hmac validation

### DIFF
--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -473,7 +473,7 @@ module Cronofy
 
     # DEPRECATED: Please use hmac_valid instead.
     def hmac_match?(args)
-      warn "[DEPRECATION] `hmac_match` is deprecated. Please use `hmac_valid` instead."
+      warn "[DEPRECATION] `hmac_match?` is deprecated. Please use `hmac_valid?` instead."
       hmac_valid?(args)
     end
 

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -475,10 +475,10 @@ module Cronofy
     #
     # args - A Hash containing the details of the push notification:
     #        :body - A String of the body of the notification.
-    #        :hmacs - A String Array of HMACs of the notification taken from the
+    #        :hmac - A String containing comma-separated values describing HMACs of the notification taken from the
     #                Cronofy-HMAC-SHA256 header.
     #
-    # Returns true if the HMAC provided matches the one calculated using the
+    # Returns true if one of the HMAC provided matches the one calculated using the
     # client secret, otherwise false.
     def hmac_match?(args)
       body = args[:body]

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -475,7 +475,7 @@ module Cronofy
     #
     # args - A Hash containing the details of the push notification:
     #        :body - A String of the body of the notification.
-    #        :hmac - A String of the HMAC of the notification taken from the
+    #        :hmacs - A String Array of HMACs of the notification taken from the
     #                Cronofy-HMAC-SHA256 header.
     #
     # Returns true if the HMAC provided matches the one calculated using the
@@ -484,11 +484,14 @@ module Cronofy
       body = args[:body]
       hmac = args[:hmac]
 
+      return false if hmac.nil? || hmac.empty?
+
       sha256 = OpenSSL::Digest.new('sha256')
       digest = OpenSSL::HMAC.digest(sha256, @client_secret, body)
       calculated = Base64.encode64(digest).strip
 
-      calculated == hmac
+      hmac_list = hmac.split(',')
+      hmac_list.include?(calculated)
     end
 
     # Public: Lists all the notification channels for the account.

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -480,7 +480,7 @@ module Cronofy
     #
     # Returns true if one of the HMAC provided matches the one calculated using the
     # client secret, otherwise false.
-    def hmac_match?(args)
+    def hmac_valid?(args)
       body = args[:body]
       hmac = args[:hmac]
 

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -471,6 +471,12 @@ module Cronofy
       parse_json(Channel, "channel", response)
     end
 
+    # DEPRECATED: Please use hmac_valid instead.
+    def hmac_match?(args)
+      warn "[DEPRECATION] `hmac_match` is deprecated. Please use `hmac_valid` instead."
+      hmac_valid?(args)
+    end
+
     # Public: Verifies a HMAC from a push notification using the client secret.
     #
     # args - A Hash containing the details of the push notification:

--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -2481,27 +2481,27 @@ describe Cronofy::Client do
     let(:body) { "{\"example\":\"well-known\"}" }
 
     it "verifies the correct HMAC" do
-      expect(client.hmac_match?(body: body, hmac: "6r2/HjBkqymGegX0wOfifieeUXbbHwtV/LohHS+jv6c=")).to be true
+      expect(client.hmac_valid?(body: body, hmac: "6r2/HjBkqymGegX0wOfifieeUXbbHwtV/LohHS+jv6c=")).to be true
     end
 
     it "rejects an incorrect HMAC" do
-      expect(client.hmac_match?(body: body, hmac: "something-else")).to be false
+      expect(client.hmac_valid?(body: body, hmac: "something-else")).to be false
     end
 
     it "verifies the correct HMAC when one of the multiple HMACs splitted by ',' match" do
-      expect(client.hmac_match?(body: body, hmac: "6r2/HjBkqymGegX0wOfifieeUXbbHwtV/LohHS+jv6c=,something-else")).to be true
+      expect(client.hmac_valid?(body: body, hmac: "6r2/HjBkqymGegX0wOfifieeUXbbHwtV/LohHS+jv6c=,something-else")).to be true
     end
 
     it "rejects incorrect when multiple HMACs splitted by ',' don't match" do
-      expect(client.hmac_match?(body: body, hmac: "something-else,something-else2")).to be false
+      expect(client.hmac_valid?(body: body, hmac: "something-else,something-else2")).to be false
     end
 
     it "rejects if empty HMAC" do
-      expect(client.hmac_match?(body: body, hmac: "")).to be false
+      expect(client.hmac_valid?(body: body, hmac: "")).to be false
     end
 
     it "rejects if nil HMAC" do
-      expect(client.hmac_match?(body: body, hmac: nil)).to be false
+      expect(client.hmac_valid?(body: body, hmac: nil)).to be false
     end
   end
 

--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -2487,6 +2487,22 @@ describe Cronofy::Client do
     it "rejects an incorrect HMAC" do
       expect(client.hmac_match?(body: body, hmac: "something-else")).to be false
     end
+
+    it "verifies the correct HMAC when one of the multiple HMACs splitted by ',' match" do
+      expect(client.hmac_match?(body: body, hmac: "6r2/HjBkqymGegX0wOfifieeUXbbHwtV/LohHS+jv6c=,something-else")).to be true
+    end
+
+    it "rejects incorrect when multiple HMACs splitted by ',' don't match" do
+      expect(client.hmac_match?(body: body, hmac: "something-else,something-else2")).to be false
+    end
+
+    it "rejects if empty HMAC" do
+      expect(client.hmac_match?(body: body, hmac: "")).to be false
+    end
+
+    it "rejects if nil HMAC" do
+      expect(client.hmac_match?(body: body, hmac: nil)).to be false
+    end
   end
 
   describe "Smart Invite" do


### PR DESCRIPTION
Allowing multiple hmacs to be passed within the same String splitter by ','. Returns true, If any of the provided ones match the calculated one using client secret, otherwise false.