### PR TITLE
Add client secret only auth for availability

### DIFF
--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -844,7 +844,7 @@ module Cronofy
 
       translate_available_periods(options[:query_periods] || options[:available_periods])
 
-      response = post("/v1/availability", options)
+      response = availability_post("/v1/availability", options)
 
       parse_collections(
         response,
@@ -1809,6 +1809,17 @@ module Cronofy
 
     def raw_post(url, body)
       wrapped_request { @auth.api_client.request(:post, url, json_request_args(body)) }
+    end
+
+    # Availability Query could originally be authenticated via an access_token
+    # Whilst it should be authed via an API key now, we allow it to fallback for
+    # backward compatibility
+    def availability_post(url, body)
+      if @auth.api_key
+        wrapped_request { api_key!.post(url, json_request_args(body)) }
+      else
+        post(url, body)
+      end
     end
 
     def wrapped_request

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -1817,8 +1817,10 @@ module Cronofy
     def availability_post(url, body)
       if @auth.api_key
         wrapped_request { api_key!.post(url, json_request_args(body)) }
-      else
+      elsif @auth.access_token
         post(url, body)
+      else
+        api_key!
       end
     end
 

--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -1809,6 +1809,28 @@ describe Cronofy::Client do
         it_behaves_like 'a Cronofy request'
         it_behaves_like 'a Cronofy request with mapped return value'
       end
+
+      context "when trying to auth without a client_secret or access_token" do
+        let(:client) { Cronofy::Client.new }
+
+        let(:participants) do
+          { members: %w{acc_567236000909002 acc_678347111010113} }
+        end
+
+        let(:required_duration) { 60 }
+
+        let(:available_periods) do
+          [
+            { start: Time.parse("2017-01-03T09:00:00Z"), end: Time.parse("2017-01-03T18:00:00Z") },
+            { start: Time.parse("2017-01-04T09:00:00Z"), end: Time.parse("2017-01-04T18:00:00Z") },
+          ]
+        end
+
+
+        it "raises an API Key error" do
+          expect{ subject }.to raise_error(Cronofy::CredentialsMissingError)
+        end
+      end
     end
   end
 

--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -1257,6 +1257,17 @@ describe Cronofy::Client do
       let(:request_url) { 'https://api.cronofy.com/v1/availability' }
       let(:request_headers) { json_request_headers }
 
+      let(:client_id) { 'example_id' }
+      let(:client_secret) { 'example_secret' }
+      let(:token) { client_secret }
+
+      let(:client) do
+        Cronofy::Client.new(
+          client_id: client_id,
+          client_secret: client_secret,
+        )
+      end
+
       let(:request_body) do
         {
           "participants" => [
@@ -1765,6 +1776,34 @@ describe Cronofy::Client do
             required_duration: required_duration,
             query_periods: query_periods
           )
+        end
+
+        it_behaves_like 'a Cronofy request'
+        it_behaves_like 'a Cronofy request with mapped return value'
+      end
+
+      context "when trying to auth with only an access_token, as originally implemented" do
+        let(:access_token) { "access_token_123"}
+        let(:client) { Cronofy::Client.new(access_token: access_token) }
+        let(:request_headers) do
+          {
+            "Authorization" => "Bearer #{access_token}",
+            "User-Agent" => "Cronofy Ruby #{::Cronofy::VERSION}",
+            "Content-Type" => "application/json; charset=utf-8",
+          }
+        end
+
+        let(:participants) do
+          { members: %w{acc_567236000909002 acc_678347111010113} }
+        end
+
+        let(:required_duration) { 60 }
+
+        let(:available_periods) do
+          [
+            { start: Time.parse("2017-01-03T09:00:00Z"), end: Time.parse("2017-01-03T18:00:00Z") },
+            { start: Time.parse("2017-01-04T09:00:00Z"), end: Time.parse("2017-01-04T18:00:00Z") },
+          ]
         end
 
         it_behaves_like 'a Cronofy request'


### PR DESCRIPTION
Add a new auth helper for the availability API, which attempts to auth via client_secret first, falling back to access_token (for backward compatibility with the original version of the availability API), or raising an exception if neither is available.

Resolves [#97]