### PR TITLE
Update Oauth2 dependency to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.40.0]
+
+ * Update version of [OAuth2](https://rubygems.org/gems/oauth2) required [#102]
+
 ## [0.39.0]
 
  * Add conferencing services authorization
@@ -222,6 +226,7 @@
 [0.37.7]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.37.7
 [0.38.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/0.38.0
 [0.39.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/0.39.0
+[0.40.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.40.0
 
 [#13]: https://github.com/cronofy/cronofy-ruby/pull/13
 [#16]: https://github.com/cronofy/cronofy-ruby/pull/16
@@ -270,5 +275,6 @@
 [#97]: https://github.com/cronofy/cronofy-ruby/pull/97
 [#99]: https://github.com/cronofy/cronofy-ruby/pull/99
 [#100]: https://github.com/cronofy/cronofy-ruby/pull/100
+[#102]: https://github.com/cronofy/cronofy-ruby/pull/102
 [#104]: https://github.com/cronofy/cronofy-ruby/pull/104
 [#108]: https://github.com/cronofy/cronofy-ruby/pull/108

--- a/cronofy.gemspec
+++ b/cronofy.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir['spec/**/*.rb']
 
   spec.add_runtime_dependency "hashie", ">= 2.1", "< 5"
-  spec.add_runtime_dependency "oauth2", "~> 2.0", ">= 2.0.4"
+  spec.add_runtime_dependency "oauth2", ">= 2.0.4"
 
   spec.add_development_dependency "bundler", ">=  1.6", "< 3"
   spec.add_development_dependency "rake",    "~> 10.0"

--- a/cronofy.gemspec
+++ b/cronofy.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir['spec/**/*.rb']
 
   spec.add_runtime_dependency "hashie", ">= 2.1", "< 5"
-  spec.add_runtime_dependency "oauth2", "~> 1.0"
+  spec.add_runtime_dependency "oauth2", "~> 2.0"
 
   spec.add_development_dependency "bundler", ">=  1.6", "< 3"
   spec.add_development_dependency "rake",    "~> 10.0"

--- a/cronofy.gemspec
+++ b/cronofy.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir['spec/**/*.rb']
 
   spec.add_runtime_dependency "hashie", ">= 2.1", "< 5"
-  spec.add_runtime_dependency "oauth2", "~> 2.0"
+  spec.add_runtime_dependency "oauth2", "~> 2.0", ">= 2.0.4"
 
   spec.add_development_dependency "bundler", ">=  1.6", "< 3"
   spec.add_development_dependency "rake",    "~> 10.0"

--- a/lib/cronofy/api_key.rb
+++ b/lib/cronofy/api_key.rb
@@ -15,6 +15,7 @@ module Cronofy
     # @see Client#request
     def request(verb, path, opts = {}, &block)
       configure_authentication!(opts)
+      opts = { snaky: false }.merge(opts)
       do_request { @client.request(verb, path, opts, &block) }
     end
 

--- a/lib/cronofy/auth.rb
+++ b/lib/cronofy/auth.rb
@@ -16,8 +16,8 @@ module Cronofy
 
       @client_credentials_missing = blank?(client_id) || blank?(client_secret)
 
-      @auth_client = OAuth2::Client.new(client_id, client_secret, site: ::Cronofy.app_url(data_center), connection_opts: { headers: { "User-Agent" => "Cronofy Ruby #{::Cronofy::VERSION}" } })
-      @api_client = OAuth2::Client.new(client_id, client_secret, site: ::Cronofy.api_url(data_center), connection_opts: { headers: { "User-Agent" => "Cronofy Ruby #{::Cronofy::VERSION}" } })
+      @auth_client = OAuth2::Client.new(client_id, client_secret, site: ::Cronofy.app_url(data_center), auth_scheme: :request_body, connection_opts: { headers: { "User-Agent" => "Cronofy Ruby #{::Cronofy::VERSION}" } })
+      @api_client = OAuth2::Client.new(client_id, client_secret, site: ::Cronofy.api_url(data_center), auth_scheme: :request_body, connection_opts: { headers: { "User-Agent" => "Cronofy Ruby #{::Cronofy::VERSION}" } })
 
       set_access_token(access_token, refresh_token) if access_token || refresh_token
       set_api_key(client_secret) if client_secret

--- a/lib/cronofy/version.rb
+++ b/lib/cronofy/version.rb
@@ -1,3 +1,3 @@
 module Cronofy
-  VERSION = "0.37.7".freeze
+  VERSION = "0.40.0".freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,4 @@ require 'ostruct'
 require 'cronofy'
 
 require 'webmock/rspec'
+require 'securerandom'


### PR DESCRIPTION
Will resolve #102 as well as avoiding v1.4.8 being picked up by consumers, as that particular version has a bug.