### PR TITLE
Add conferencing services authorization

### DIFF
--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -323,7 +323,7 @@ module Cronofy
     # Raises Cronofy::AuthenticationFailureError if the client ID and secret are
     # not valid.
     # Raises Cronofy::CredentialsMissingError if no credentials available.
-    def get_conferencing_service_authorization(redirect_uri)
+    def get_conferencing_service_authorizations(redirect_uri)
       data = { redirect_uri: redirect_uri }
 
       response = post "/v1/conferencing_service_authorizations", data

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -312,6 +312,24 @@ module Cronofy
       nil
     end
 
+    # Public: Returns an URL where users can authorize access to their conferencing services.
+    #
+    # See https://docs.cronofy.com/developers/api/conferencing-services/authorization/ for reference.
+    #
+    # Returns Cronofy::ConferencingServiceAuthorizationResponse with the generated URL
+    #
+    # Raises Cronofy::BadRequestError if refresh token code is unknown or has
+    # been revoked.
+    # Raises Cronofy::AuthenticationFailureError if the client ID and secret are
+    # not valid.
+    # Raises Cronofy::CredentialsMissingError if no credentials available.
+    def get_conferencing_service_authorization(redirect_uri)
+      data = { redirect_uri: redirect_uri }
+
+      response = post "/v1/conferencing_service_authorizations", data
+      parse_json(ConferencingServiceAuthorizationResponse, "authorization_request", response)
+    end
+
     class BatchBuilder
       include TimeEncoding
 

--- a/lib/cronofy/types.rb
+++ b/lib/cronofy/types.rb
@@ -417,4 +417,7 @@ module Cronofy
   class RealTimeSchedulingStatus < CronofyMash
     coerce_key :event, Event
   end
+
+  class ConferencingServiceAuthorizationResponse < CronofyMash
+  end
 end

--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -3712,7 +3712,7 @@ describe Cronofy::Client do
   end
 
   describe 'Conferencing Services' do
-    describe '#get_conferencing_service_authorization' do
+    describe '#get_conferencing_service_authorizations' do
       let(:redirect_uri) { "http://example.com/not_found" }
       let(:request_url) { "https://api.cronofy.com/v1/conferencing_service_authorizations" }
       let(:method) { :post }
@@ -3731,7 +3731,7 @@ describe Cronofy::Client do
         Cronofy::ConferencingServiceAuthorizationResponse.new(correct_response_body['authorization_request'])
       end
 
-      subject { client.get_conferencing_service_authorization(redirect_uri) }
+      subject { client.get_conferencing_service_authorizations(redirect_uri) }
 
       it_behaves_like 'a Cronofy request'
       it_behaves_like 'a Cronofy request with mapped return value'

--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -3710,4 +3710,31 @@ describe Cronofy::Client do
     it_behaves_like 'a Cronofy request'
     it_behaves_like 'a Cronofy request with mapped return value'
   end
+
+  describe 'Conferencing Services' do
+    describe '#get_conferencing_service_authorization_url' do
+      let(:redirect_uri) { "http://example.com/not_found" }
+      let(:request_url) { "https://api.cronofy.com/v1/conferencing_service_authorizations" }
+      let(:method) { :post }
+      let(:request_body) {
+        { redirect_uri: redirect_uri }
+      }
+      let(:correct_response_code) { 200 }
+      let(:correct_response_body) do
+        {
+          "authorization_request" => {
+            "url": "https://app.cronofy.com/conferencing_services/foo"
+          }
+        }
+      end
+      let(:correct_mapped_result) do
+        Cronofy::ConferencingServiceAuthorizationResponse.new(correct_response_body['authorization_request'])
+      end
+
+      subject { client.get_conferencing_service_authorization(redirect_uri) }
+
+      it_behaves_like 'a Cronofy request'
+      it_behaves_like 'a Cronofy request with mapped return value'
+    end
+  end
 end

--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -3712,7 +3712,7 @@ describe Cronofy::Client do
   end
 
   describe 'Conferencing Services' do
-    describe '#get_conferencing_service_authorization_url' do
+    describe '#get_conferencing_service_authorization' do
       let(:redirect_uri) { "http://example.com/not_found" }
       let(:request_url) { "https://api.cronofy.com/v1/conferencing_service_authorizations" }
       let(:method) { :post }


### PR DESCRIPTION
Adds support for generating an url for users to authorize their conference providers
https://docs.cronofy.com/developers/api/conferencing-services/authorization/