### PR TITLE
Add ability to pass query_slots parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.41.0]
+
+ * Adds support for the query_slots parameter [#111]
+
 ## [0.40.0]
 
  * Update version of [OAuth2](https://rubygems.org/gems/oauth2) required [#102]
@@ -227,6 +231,7 @@
 [0.38.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/0.38.0
 [0.39.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/0.39.0
 [0.40.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.40.0
+[0.41.0]: https://github.com/cronofy/cronofy-ruby/releases/tag/v0.41.0
 
 [#13]: https://github.com/cronofy/cronofy-ruby/pull/13
 [#16]: https://github.com/cronofy/cronofy-ruby/pull/16
@@ -278,3 +283,4 @@
 [#102]: https://github.com/cronofy/cronofy-ruby/pull/102
 [#104]: https://github.com/cronofy/cronofy-ruby/pull/104
 [#108]: https://github.com/cronofy/cronofy-ruby/pull/108
+[#111]: https://github.com/cronofy/cronofy-ruby/pull/111

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -835,8 +835,10 @@ module Cronofy
     #                                each must specify a start and end Time.
     #           :start_interval    - An Integer representing the start interval
     #                                of minutes for the availability query.
-    #           :buffer            - An Hash containing the buffer to apply to
+    #           :buffer            - A Hash containing the buffer to apply to
     #                                the availability query.
+    #           :query_slots       - A Hash containing the query slots to be
+    #                                used in the availability query.
     #
     # Returns an Array of AvailablePeriods.
     #
@@ -861,10 +863,12 @@ module Cronofy
         options[:buffer] = map_availability_buffer(buffer)
       end
 
-      translate_available_periods(options[:query_periods] || options[:available_periods])
+      if query_periods = options[:query_periods] || options[:available_periods]
+        translate_available_periods(query_periods)
+      end
 
       if query_slots = options[:query_slots]
-        translate_query_slots(options:[:query_slots])
+        translate_query_slots(query_slots)
       end
 
       response = availability_post("/v1/availability", options)
@@ -1722,7 +1726,7 @@ module Cronofy
     end
 
     def translate_query_slots(query_slots)
-      periods.each do |params|
+      query_slots.each do |params|
         QUERY_SLOTS_TIME_PARAMS.select { |tp| params.key?(tp) }.each do |tp|
           params[tp] = to_iso8601(params[tp])
         end

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -1060,7 +1060,9 @@ module Cronofy
     #                                         call
     #                    :required_duration - A hash stating the length of time the event will
     #                                         last for
-    #                    :query_periods     - A hash stating the available periods for the event
+    #                    :query_periods     - A Hash stating the available periods for the event
+    #                    :query_slots       - A Hash containing the query slots to be
+    #                                         used in the availability query.
     #                    :start_interval    - An Integer representing the start interval
     #                                         of minutes for the availability query.
     #                    :buffer            - An Hash containing the buffer to apply to
@@ -1137,7 +1139,14 @@ module Cronofy
         end
       end
 
-      translate_available_periods(availability[:query_periods] || availability[:available_periods])
+      if query_periods = availability[:query_periods] || availability[:available_periods]
+        translate_available_periods(query_periods)
+      end
+
+      if query_slots = availability[:query_slots]
+        translate_query_slots(query_slots)
+      end
+
       body[:availability] = availability
 
       response = raw_post("/v1/real_time_scheduling", body)

--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -863,6 +863,10 @@ module Cronofy
 
       translate_available_periods(options[:query_periods] || options[:available_periods])
 
+      if query_slots = options[:query_slots]
+        translate_query_slots(options:[:query_slots])
+      end
+
       response = availability_post("/v1/availability", options)
 
       parse_collections(
@@ -1717,6 +1721,14 @@ module Cronofy
       end
     end
 
+    def translate_query_slots(query_slots)
+      periods.each do |params|
+        QUERY_SLOTS_TIME_PARAMS.select { |tp| params.key?(tp) }.each do |tp|
+          params[tp] = to_iso8601(params[tp])
+        end
+      end
+    end
+
     def map_availability_participants(participants)
       case participants
       when Hash
@@ -1845,6 +1857,10 @@ module Cronofy
     AVAILABLE_PERIODS_TIME_PARAMS = %i{
       start
       end
+    }.freeze
+
+    QUERY_SLOTS_TIME_PARAMS = %i{
+      start
     }.freeze
 
     FREE_BUSY_DEFAULT_PARAMS = { tzid: "Etc/UTC" }.freeze

--- a/lib/cronofy/version.rb
+++ b/lib/cronofy/version.rb
@@ -1,3 +1,3 @@
 module Cronofy
-  VERSION = "0.40.0".freeze
+  VERSION = "0.41.0".freeze
 end

--- a/spec/lib/cronofy/client_spec.rb
+++ b/spec/lib/cronofy/client_spec.rb
@@ -1783,6 +1783,51 @@ describe Cronofy::Client do
         it_behaves_like 'a Cronofy request with mapped return value'
       end
 
+      context 'when given query_slots instead of available_periods with start interval' do
+        let(:participants) do
+          { members: %w{acc_567236000909002 acc_678347111010113} }
+        end
+
+        let(:required_duration) { 60 }
+
+        let(:query_slots) do
+          [
+            { start: Time.parse("2017-01-03T09:00:00Z")},
+            { start: Time.parse("2017-01-04T09:00:00Z") },
+          ]
+        end
+
+        let(:request_body) do
+          {
+            "participants" => [
+              {
+                "members" => [
+                  { "sub" => "acc_567236000909002" },
+                  { "sub" => "acc_678347111010113" }
+                ],
+                "required" => "all"
+              }
+            ],
+            "query_slots" => [
+              { "start" => "2017-01-03T09:00:00Z" },
+              { "start" => "2017-01-04T09:00:00Z" }
+            ],
+            "required_duration" => { "minutes" => 60 },
+          }
+        end
+
+        subject do
+          client.availability(
+            participants: participants,
+            required_duration: required_duration,
+            query_slots: query_slots
+          )
+        end
+
+        it_behaves_like 'a Cronofy request'
+        it_behaves_like 'a Cronofy request with mapped return value'
+      end
+
       context "when trying to auth with only an access_token, as originally implemented" do
         let(:access_token) { "access_token_123"}
         let(:client) { Cronofy::Client.new(access_token: access_token) }
@@ -2361,6 +2406,56 @@ describe Cronofy::Client do
         before do
           availability[:query_periods] = availability.delete(:available_periods)
           mapped_availability[:query_periods] = mapped_availability.delete(:available_periods)
+        end
+      end
+
+      context 'when passing query slots' do
+        let(:availability) do
+          {
+            participants: [
+              {
+                members: [{
+                  sub: "acc_567236000909002",
+                  calendar_ids: ["cal_n23kjnwrw2_jsdfjksn234"]
+                }],
+                required: 'all'
+              }
+            ],
+            required_duration: { minutes: 60 },
+            query_slots: [
+              { start: Time.utc(2017, 1, 1, 9, 00) }, 
+              { start: Time.utc(2017, 1, 1, 17, 00) }
+            ],
+            buffer: {
+              before: { minutes: 30 },
+              after: { minutes: 45 },
+            }
+          }
+        end
+  
+        let(:mapped_availability) do
+          {
+            participants: [
+              {
+                members: [{
+                  sub: "acc_567236000909002",
+                  calendar_ids: ["cal_n23kjnwrw2_jsdfjksn234"]
+                }],
+                required: 'all'
+              }
+            ],
+            required_duration: { minutes: 60 },
+            buffer: {
+              before: { minutes: 30 },
+              after: { minutes: 45 },
+            },
+            query_slots: [
+              { start: Time.utc(2017, 1, 1, 9, 00) },
+              { start: Time.utc(2017, 1, 1, 17, 00) }
+            ],
+          }
+        it_behaves_like 'a Cronofy request'
+        it_behaves_like 'a Cronofy request with mapped return value'
         end
       end
     end


### PR DESCRIPTION
Adds the ability to pass `query_slots` to both the availability query endpoint and to real time scheduling request creation.

Resolves #110 