### PR TITLE
Make state parameter for authorize_with_service_account optional

### DIFF
--- a/lib/cronofy/client.rb
+++ b/lib/cronofy/client.rb
@@ -651,6 +651,8 @@ module Cronofy
     # scope - Array or String of scopes describing the access to
     #         request from the user to the users calendars (required).
     # callback_url - the url to callback to
+    # state - A value that will be returned to you unaltered along with the
+    #         authorization request decision.
     #
     # Returns nothing
     #
@@ -659,7 +661,7 @@ module Cronofy
     # longer valid.
     # Raises Cronofy::TooManyRequestsError if the request exceeds the rate
     # limits for the application.
-    def authorize_with_service_account(email, scope, callback_url, state)
+    def authorize_with_service_account(email, scope, callback_url, state=nil)
       if scope.respond_to?(:join)
         scope = scope.join(' ')
       end


### PR DESCRIPTION
This is to fix #116. I just made the state parameter in `authorize_with_service_account` default to nil and documented the parameter in the comments. I copied the documentation from https://docs.cronofy.com/developers/api/enterprise-connect/delegated-access/#param-state